### PR TITLE
feat: axion dev — subprocess lifecycle, readiness polling, port conflict detection (issue #28)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,13 +11,15 @@
   ],
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "commander": "^12.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.1"
   }
 }

--- a/cli/src/commands/dev.test.ts
+++ b/cli/src/commands/dev.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for axion dev lifecycle helpers — issue #28.
+ *
+ * Uses real network I/O (TCP / HTTP) so there are no mocks to drift.
+ */
+
+import net from "node:net";
+import http from "node:http";
+import { describe, it, expect, afterEach } from "vitest";
+import { isPortInUse, pollUntilReady } from "./dev.js";
+
+// ── isPortInUse ───────────────────────────────────────────────────────────────
+
+describe("isPortInUse", () => {
+  // Pick a high ephemeral port unlikely to be in use in CI.
+  const TEST_PORT = 54_321;
+  let server: net.Server | null = null;
+
+  afterEach(
+    () =>
+      new Promise<void>((resolve) => {
+        if (server) {
+          server.close(() => {
+            server = null;
+            resolve();
+          });
+        } else {
+          resolve();
+        }
+      })
+  );
+
+  it("returns false when nothing is listening on the port", async () => {
+    expect(await isPortInUse(TEST_PORT)).toBe(false);
+  });
+
+  it("returns true when a TCP server is already listening", async () => {
+    server = net.createServer();
+    await new Promise<void>((resolve) =>
+      server!.listen(TEST_PORT, "127.0.0.1", () => resolve())
+    );
+    expect(await isPortInUse(TEST_PORT)).toBe(true);
+  });
+
+  it("returns false after the server is closed", async () => {
+    // Start then stop — port should be free again.
+    const tmp = net.createServer();
+    await new Promise<void>((resolve) =>
+      tmp.listen(TEST_PORT, "127.0.0.1", () => resolve())
+    );
+    await new Promise<void>((resolve) => tmp.close(() => resolve()));
+    expect(await isPortInUse(TEST_PORT)).toBe(false);
+  });
+});
+
+// ── pollUntilReady ────────────────────────────────────────────────────────────
+
+describe("pollUntilReady", () => {
+  const TEST_PORT = 54_322;
+  let httpServer: http.Server | null = null;
+
+  afterEach(
+    () =>
+      new Promise<void>((resolve) => {
+        if (httpServer) {
+          httpServer.close(() => {
+            httpServer = null;
+            resolve();
+          });
+        } else {
+          resolve();
+        }
+      })
+  );
+
+  it("returns true immediately when the server is already up", async () => {
+    httpServer = http.createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) =>
+      httpServer!.listen(TEST_PORT, "127.0.0.1", () => resolve())
+    );
+
+    const ready = await pollUntilReady(
+      `http://127.0.0.1:${TEST_PORT}`,
+      5_000,
+      100
+    );
+    expect(ready).toBe(true);
+  });
+
+  it("returns false when the server never starts within the timeout", async () => {
+    // Nothing listening — must time out quickly.
+    const ready = await pollUntilReady(
+      `http://127.0.0.1:${TEST_PORT}`,
+      500, // very short timeout
+      100
+    );
+    expect(ready).toBe(false);
+  });
+
+  it("returns true once the server becomes available mid-poll", async () => {
+    // Start the server 300 ms after polling begins.
+    const startDelay = 300;
+    const timeout = 3_000;
+
+    setTimeout(() => {
+      httpServer = http.createServer((_req, res) => {
+        res.writeHead(200);
+        res.end("ok");
+      });
+      httpServer.listen(TEST_PORT, "127.0.0.1");
+    }, startDelay);
+
+    const ready = await pollUntilReady(
+      `http://127.0.0.1:${TEST_PORT}`,
+      timeout,
+      100
+    );
+    expect(ready).toBe(true);
+  });
+});

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -1,0 +1,220 @@
+/**
+ * axion dev — issue #28.
+ *
+ * Manages the full Vite + Axion runtime subprocess lifecycle:
+ *   1. Validate axion.config.json
+ *   2. Check port availability — clear error if port is already in use
+ *   3. Spawn Vite dev server
+ *   4. Poll until Vite responds (up to 30 s) — never shows a blank window
+ *   5. Launch the Axion runtime in dev mode (AXION_DEV=1)
+ *   6. Register SIGINT/SIGTERM handler — kills both processes cleanly
+ */
+
+import net from "node:net";
+import path from "node:path";
+import fs from "node:fs";
+import { spawn, ChildProcess } from "node:child_process";
+import { loadProjectConfig } from "../utils/config.js";
+
+export interface DevOptions {
+  /** Project root directory (defaults to cwd). */
+  cwd?: string;
+  /** Vite port (defaults to 5173). */
+  port?: number;
+}
+
+const DEFAULT_PORT = 5173;
+/** Maximum time to wait for Vite to respond before giving up. */
+const READY_TIMEOUT_MS = 30_000;
+/** How often to poll the Vite dev server during startup. */
+const POLL_INTERVAL_MS = 250;
+
+export async function dev(opts: DevOptions = {}): Promise<void> {
+  const projectRoot = path.resolve(opts.cwd ?? process.cwd());
+  const port = opts.port ?? DEFAULT_PORT;
+  const devUrl = `http://localhost:${port}`;
+
+  // ── Step 1: validate config ────────────────────────────────────────────────
+  console.log("axion dev — validating project config...");
+  let config;
+  try {
+    config = loadProjectConfig(projectRoot);
+  } catch (err) {
+    console.error(`\n  Error: ${String(err)}\n`);
+    process.exit(1);
+  }
+  console.log(`  App: ${config.axion.name} v${config.axion.version}`);
+
+  // ── Step 2: detect port conflict before starting anything ─────────────────
+  if (await isPortInUse(port)) {
+    console.error(
+      `\n  Error: Port ${port} is already in use.\n` +
+        `  Stop the process occupying port ${port}, or pass --port <n> to ` +
+        `use a different port.\n`
+    );
+    process.exit(1);
+  }
+
+  // ── Step 3: spawn Vite dev server ─────────────────────────────────────────
+  console.log(`\naxion dev — starting Vite on port ${port}...`);
+
+  const vite = spawn("npx", ["vite", "--port", String(port)], {
+    cwd: projectRoot,
+    env: process.env,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  vite.on("error", (err) => {
+    console.error(`\n  Error: Failed to start Vite: ${err.message}\n`);
+    process.exit(1);
+  });
+
+  // If Vite exits on its own (e.g. unrecoverable error), propagate the code.
+  vite.on("close", (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(`\n  Vite exited with code ${code}\n`);
+      process.exit(code);
+    }
+  });
+
+  // ── Step 4: wait until Vite is ready ──────────────────────────────────────
+  process.stdout.write(`\n  Waiting for dev server at ${devUrl}`);
+  const ready = await pollUntilReady(devUrl, READY_TIMEOUT_MS, POLL_INTERVAL_MS);
+  process.stdout.write("\n");
+
+  if (!ready) {
+    console.error(
+      `\n  Error: Dev server did not become ready within ` +
+        `${READY_TIMEOUT_MS / 1000} s at ${devUrl}.\n` +
+        `  Check Vite output above for errors.\n`
+    );
+    vite.kill();
+    process.exit(1);
+  }
+
+  console.log(`\n  ✔  Dev server ready → ${devUrl}`);
+
+  // ── Step 5: launch Axion runtime in dev mode ───────────────────────────────
+  console.log("\naxion dev — launching Axion runtime...");
+
+  const cargoRoot = findCargoRoot(projectRoot);
+  let runtime: ChildProcess | null = null;
+
+  if (cargoRoot) {
+    runtime = spawn("cargo", ["run", "--package", "axion-core"], {
+      cwd: cargoRoot,
+      env: {
+        ...process.env,
+        AXION_DEV: "1",
+        AXION_DEV_URL: devUrl,
+      },
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    runtime.on("error", (err) => {
+      console.warn(
+        `\n  Warning: Could not start Axion runtime: ${err.message}\n`
+      );
+    });
+  } else {
+    console.warn(
+      "  Warning: Cargo workspace not found — runtime will not be launched.\n" +
+        "  Run axion dev from inside your Axion project directory."
+    );
+  }
+
+  // ── Step 6: clean shutdown on Ctrl+C / SIGTERM ────────────────────────────
+  const cleanup = (signal: string) => {
+    console.log(`\naxion dev — received ${signal}, shutting down...`);
+    if (runtime && !runtime.killed) runtime.kill();
+    if (!vite.killed) vite.kill();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => cleanup("SIGINT"));
+  process.on("SIGTERM", () => cleanup("SIGTERM"));
+
+  // Keep the CLI alive until both child processes exit.
+  const pending: Promise<void>[] = [waitForClose(vite)];
+  if (runtime) pending.push(waitForClose(runtime));
+  await Promise.all(pending);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Returns `true` if a TCP listener is already bound on `port`.
+ * Used to detect port conflicts before launching Vite.
+ * Exported for testing.
+ */
+export function isPortInUse(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", (err: NodeJS.ErrnoException) => {
+      resolve(err.code === "EADDRINUSE");
+    });
+    server.once("listening", () => {
+      server.close(() => resolve(false));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+/**
+ * Poll `url` with GET requests every `intervalMs` until a response is received
+ * or `timeoutMs` elapses. Returns `true` if the server became ready.
+ * Exported for testing.
+ */
+export async function pollUntilReady(
+  url: string,
+  timeoutMs: number,
+  intervalMs: number
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(intervalMs) });
+      if (res.ok || res.status < 500) return true;
+    } catch {
+      // Not ready yet — keep polling.
+    }
+    process.stdout.write(".");
+    await sleep(intervalMs);
+  }
+  return false;
+}
+
+/** Resolve when a child process closes (any exit code). */
+function waitForClose(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => child.on("close", () => resolve()));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Walk up from `startDir` looking for a Cargo.toml with a [workspace] section.
+ * Falls back to the first directory that contains any Cargo.toml.
+ */
+function findCargoRoot(startDir: string): string | null {
+  let dir = startDir;
+  let fallback: string | null = null;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const cargoToml = path.join(dir, "Cargo.toml");
+    if (fs.existsSync(cargoToml)) {
+      const content = fs.readFileSync(cargoToml, "utf-8");
+      if (content.includes("[workspace]")) return dir;
+      if (!fallback) fallback = dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return fallback;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 /**
- * Axion CLI entry point — issue #24.
+ * Axion CLI entry point.
  *
  * Commands:
+ *   axion dev     — start Vite dev server + Axion runtime
  *   axion build   — produce a distributable Windows .exe
  */
 
 import { Command } from "commander";
 import { build } from "./commands/build.js";
+import { dev } from "./commands/dev.js";
 
 const program = new Command();
 
@@ -15,6 +17,18 @@ program
   .name("axion")
   .description("Axion — React-first desktop runtime for Windows")
   .version("0.1.0");
+
+program
+  .command("dev")
+  .description("Start Vite dev server and the Axion runtime together")
+  .option(
+    "--cwd <path>",
+    "Project root directory (defaults to current working directory)"
+  )
+  .option("--port <n>", "Vite dev server port (defaults to 5173)", parseInt)
+  .action(async (opts: { cwd?: string; port?: number }) => {
+    await dev({ cwd: opts.cwd, port: opts.port });
+  });
 
 program
   .command("build")

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.0",
+        "vitest": "^1.6.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {


### PR DESCRIPTION
## Summary

- Adds `cli/src/commands/dev.ts` — the `axion dev` command
- Registers `axion dev` in `cli/src/index.ts` with `--cwd` and `--port` flags
- Adds Vitest to the CLI package and 6 tests covering the two exported helpers

### How it works

1. **Config validation** — loads `axion.config.json` + `permissions.json` (reuses `loadProjectConfig`)
2. **Port conflict detection** — probes the port with a TCP `net.Server` before spawning anything; exits with a clear message if already in use
3. **Vite startup** — spawns `npx vite --port <n>` and polls `http://localhost:<port>` every 250 ms (up to 30 s) before proceeding — the native window never shows a blank page due to a race
4. **Runtime launch** — spawns `cargo run --package axion-core` with `AXION_DEV=1` and `AXION_DEV_URL=http://localhost:<port>` after Vite is confirmed ready
5. **Clean shutdown** — `SIGINT` / `SIGTERM` handler kills both child processes; Ctrl+C leaves no zombies
6. **`--port` flag** — overrides the default port (5173) for any environment where the default is taken

### Tests (`cli/src/commands/dev.test.ts`)

| Test | What it covers |
|---|---|
| `isPortInUse` — nothing listening | returns `false` |
| `isPortInUse` — TCP server bound | returns `true` |
| `isPortInUse` — after server closes | returns `false` again |
| `pollUntilReady` — server already up | returns `true` immediately |
| `pollUntilReady` — server never starts | returns `false` after timeout |
| `pollUntilReady` — server starts mid-poll | returns `true` once available |

All 6 tests use real TCP/HTTP — no mocks.

## Test plan

- [x] `npm run build` in `cli/` — TypeScript compiles cleanly
- [x] `npm test` in `cli/` — 6/6 tests pass

Closes #28